### PR TITLE
Use $JAVA_HOME insted of a fixed path

### DIFF
--- a/pi.sh
+++ b/pi.sh
@@ -3,8 +3,8 @@
 #
 VERSION=2.0.1
 LIBRARY=picam-$VERSION.so
-JNI_INCLUDE=/usr/lib/jvm/java-9-openjdk-armhf/include
-JNI_LIB=/usr/lib/jvm/java-9-openjdk-armhf/lib
+JNI_INCLUDE=$JAVA_HOME/include
+JNI_LIB=$JAVA_HOME/lib
 PI_INCLUDE=/opt/vc/include
 PI_LIB=/opt/vc/lib
 LDFLAGS="-lc -lmmal -lmmal_core -lmmal_util"


### PR DESCRIPTION
Not all PIs have java 9, for example, i installed java 16 on my PI, and it came with java 11, where as my pi zero has java 8, etc.